### PR TITLE
Update consistency_analysis.py

### DIFF
--- a/TransRepair/consistency_analysis.py
+++ b/TransRepair/consistency_analysis.py
@@ -70,10 +70,11 @@ def wdiff_and_cut(sentence1, sentence2):
                     continue
 
             if d[0] != '+':
-                if d[0] == '-':
-                    sub_sentence1 += d[2:].strip()
-                elif d[0] == ' ':
-                    sub_sentence1 += d.strip()
+                if d[0] == '?':
+                    if d[0] == '-':
+                        sub_sentence1 += d[2:].strip()
+                    else:
+                        sub_sentence1 += d.strip()
         sub_sentences1.append(sub_sentence1)
 
     for i in range(1, num_diff2 + 1):
@@ -85,10 +86,11 @@ def wdiff_and_cut(sentence1, sentence2):
                 if count == i:
                     continue
             if d[0] != '-':
-                if d[0] == '+':
-                    sub_sentence2 += d[2:].strip()
-                elif d[0] == ' ':
-                    sub_sentence2 += d.strip()
+                if d[0] == '?':
+                    if d[0] == '+':
+                        sub_sentence2 += d[2:].strip()
+                    else:
+                        sub_sentence2 += d.strip()
         sub_sentences2.append(sub_sentence2)
     return sub_sentences1, sub_sentences2
 

--- a/TransRepair/consistency_analysis.py
+++ b/TransRepair/consistency_analysis.py
@@ -72,7 +72,7 @@ def wdiff_and_cut(sentence1, sentence2):
             if d[0] != '+':
                 if d[0] == '-':
                     sub_sentence1 += d[2:].strip()
-                else:
+                elif d[0] == ' ':
                     sub_sentence1 += d.strip()
         sub_sentences1.append(sub_sentence1)
 
@@ -87,7 +87,7 @@ def wdiff_and_cut(sentence1, sentence2):
             if d[0] != '-':
                 if d[0] == '+':
                     sub_sentence2 += d[2:].strip()
-                else:
+                elif d[0] == ' ':
                     sub_sentence2 += d.strip()
         sub_sentences2.append(sub_sentence2)
     return sub_sentences1, sub_sentences2


### PR DESCRIPTION
Remove the diff token "? ^\n" when trying to compare two sentence in difflib.

![image](https://user-images.githubusercontent.com/30165828/224670661-68a63521-9c93-44b7-9b4b-f089fceeaf50.png)
![image](https://user-images.githubusercontent.com/30165828/224670602-a369c0a5-f176-4495-aa54-a2d253a69c49.png)
![image](https://user-images.githubusercontent.com/30165828/224670751-13b8b8c2-5b9d-4f18-b359-eefe086c111f.png)
![image](https://user-images.githubusercontent.com/30165828/224670824-8dafa796-1926-4a45-ab1c-3d368f8c271d.png)

